### PR TITLE
Update routes to not remount if previously mounted

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Qunit::Rails::Engine.routes.draw do
 end
 
 Rails.application.routes.draw do
-  mount Qunit::Rails::Engine => '/qunit'
+  unless Rails.application.routes.named_routes.routes[:qunit_rails]
+    mount Qunit::Rails::Engine => '/qunit'
+  end
 end


### PR DESCRIPTION
I have been having issues using qunit while simultaneously using wildcard routes. My app utilizes a necessary route like:

``` ruby
  get '/*path' => 'high_voltage/pages#show',  id: 'index'
```

which overrides the default qunit route since that seems to get mounted after this wildcard route. I can prevent this from happening by manually mounting it in my routes like so:

``` ruby
mount Qunit::Rails::Engine => '/qunit'
```

but then it gets remounted in the gem, and the entire rails application complains when I do anything (run tests, list routes, run zeus, etc.) because there are 2 named routes with the same name. 

So this little fix will not remount the engine if it was previously mounted in the routes.rb in the rails app, which will allow the engine to get mounted prior to any wildcard routes.
