### PR TITLE
Fix routes for rails 4.1

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Qunit::Rails::Engine.routes.draw do
   root to: 'test#index'
-  match ':action', controller: 'test'
+  get ':action', controller: 'test'
 end
 
 Rails.application.routes.draw do


### PR DESCRIPTION
Using match without :via in the routes seem to be no longer supported. I've changed the route to get only. 
